### PR TITLE
Fix migration chain icon

### DIFF
--- a/db/migrations/20230327121402-add-icon-column-to-chains.js
+++ b/db/migrations/20230327121402-add-icon-column-to-chains.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn("chains", "icon", {
+      type: Sequelize.STRING
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn("chains", "icon");
+  }
+};


### PR DESCRIPTION
Reason: migrations break because in some files we call models that don't have all the necessary fields.


